### PR TITLE
Allow passing build options in message

### DIFF
--- a/bin/argus-build
+++ b/bin/argus-build
@@ -2,25 +2,35 @@
 ## run a single argus build directly
 
 require 'argus'
+require 'optparse'
 
-usage = 'argus-build org/repo:branch [sha]'
+USAGE = 'argus-build org/repo:branch'
 
-if ARGV.empty?
-  puts "Usage: #{usage}"
-  exit
-end
+## msg to send to argus runner
+msg = {
+  build_options: {}
+}
+
+OptionParser.new do |opts|
+  opts.banner = USAGE
+
+  opts.on('-s', '--sha SHA', 'Git SHA to build') do |s|
+    msg[:sha] = s
+  end
+
+  opts.on('-d', '--dockerfile FILENAME', 'Name of Dockerfile') do |d|
+    msg[:build_options][:dockerfile] = d
+  end
+
+  opts.on('-n', '--no-cache', 'Invalidate docker build cache') do |n|
+    msg[:build_options][:nocache] = true
+  end
+end.parse!
+
+abort("Usage: #{USAGE}") if ARGV.empty?
 
 ## parse github repo
-org, repo, branch = ARGV[0].split(/[\/:]+/, 3)
-sha = ARGV[1] || nil
-
-## incoming message from sqs
-msg = {
-  org:    org,
-  repo:   repo,
-  branch: branch,
-  sha:    sha
-}
+msg[:org], msg[:repo], msg[:branch] = ARGV[0].split(/[\/:]+/, 3)
 
 ## prevent timeout on docker api operations (e.g. long bundle install during build)
 Excon.defaults[:write_timeout] = ENV.fetch('DOCKER_WRITE_TIMEOUT', 10000)

--- a/bin/argus-build
+++ b/bin/argus-build
@@ -23,7 +23,7 @@ msg = {
 }
 
 ## prevent timeout on docker api operations (e.g. long bundle install during build)
-Excon.defaults[:write_timeout] = ENV.fetch('DOCKER_WRITE_TIMEOUT', 1000)
-Excon.defaults[:read_timeout]  = ENV.fetch('DOCKER_READ_TIMEOUT',  1000)
+Excon.defaults[:write_timeout] = ENV.fetch('DOCKER_WRITE_TIMEOUT', 10000)
+Excon.defaults[:read_timeout]  = ENV.fetch('DOCKER_READ_TIMEOUT',  10000)
 
 Argus::Runner.new(msg)

--- a/lib/argus/docker.rb
+++ b/lib/argus/docker.rb
@@ -28,12 +28,12 @@ module Argus
       end
     end
 
-    ## build docker image
-    def build!
+    ## build docker image, with optional API /build params
+    def build!(options = {})
       puts "building #{self}"
 
       @build_time = Benchmark.realtime do
-        @image = Docker::Image.build_from_dir('.', dockerfile: 'Dockerfile') do |chunk|
+        @image = Docker::Image.build_from_dir('.', options) do |chunk|
           chunk.split(/[\r\n]+/).each do |line| # latest docker jams multiple streams into chunk
             begin
               stream = JSON.parse(line)['stream']

--- a/lib/argus/runner.rb
+++ b/lib/argus/runner.rb
@@ -65,7 +65,8 @@ module Argus
         git.pull              # get the git repo
         raise ArgusError, "git sha not found: #{git}" unless git.sha
 
-        img.build!              # build docker image
+        options = msg.fetch(:build_options, {})
+        img.build!(options) # build docker image
         raise ArgusError, 'docker build failed' unless img.is_ok?
 
         short_sha = git.sha.slice(0,7) # human-readable sha for messages


### PR DESCRIPTION
Fixes #1 

Incoming message hash can now have a subhash like:

```
build_options: {
  nocache: true
}
```

which can include any docker `/build` API options.

Also adds cmdline options `--no-cache` and `--dockerfile` to `argus-build` tool.
